### PR TITLE
(hotfix) HTML header layout broken

### DIFF
--- a/lib/isodoc/m3d/html/htmlstyle.scss
+++ b/lib/isodoc/m3d/html/htmlstyle.scss
@@ -623,19 +623,18 @@ p {
       color: white;
   }
 
-   .docinfo {
-      margin-top: 2em;
-      margin-bottom: 3em;
-  }
+.docinfo {
+    margin-top: 2em;
+    margin-bottom: 3em;
+}
 
 
-  .coverpage-doc-identity {
-    height: 100px;
+.coverpage-doc-identity {
+    min-height: 100px;
     width: 100%;
     background-size: 240px 80px;
     margin: auto;
-  }
-
+}
 
   .coverpage-title .title-second {
     display: none;


### PR DESCRIPTION
#42  fix for html layout header, changed `coverpage-doc-identity` class `height` attribute to `min-height`

with fix:

![image](https://user-images.githubusercontent.com/1158036/84138257-a6c41880-aa56-11ea-895b-c2265efbd601.png)
![image](https://user-images.githubusercontent.com/1158036/84138282-afb4ea00-aa56-11ea-8094-710e7f02263c.png)
